### PR TITLE
Additional parameters 'Label' and 'Closed' added to TAggrResampler

### DIFF
--- a/src/glib/mine/signalproc.cpp
+++ b/src/glib/mine/signalproc.cpp
@@ -914,9 +914,10 @@ TAggrResampler::TAggrResampler(const PJsonVal& ParamVal) {
 }
 
 TAggrResampler::TAggrResampler(const uint64& Interval, const TStr& AggType,
-    const double& DefaultValue, const TStr& RoundStart, const TTm& Start,
-    const TStr& Closed, const TStr& Label)
-    : IntervalMSecs(Interval), Type(GetType(AggType)), DefaultVal(DefaultValue) {
+    const double& DefaultValue, const TStr& RoundStart, const TStr& Closed,
+    const TStr& Label, const TTm& Start)
+    : IntervalMSecs(Interval), Type(GetType(AggType)), DefaultVal(DefaultValue),
+      Closed(Closed), Label(Label) {
 
     EAssertR(RoundStart == "" || RoundStart == "h" || RoundStart == "m" ||
         RoundStart == "s", "TAggrResampler: roundStart should be 'h', 'm' or 's'");
@@ -937,6 +938,8 @@ PJsonVal TAggrResampler::GetParams() const {
     Result->AddToObj("aggType", GetTypeStr(Type));
     Result->AddToObj("roundStart", RoundStart);
     Result->AddToObj("defaultValue", DefaultVal);
+    Result->AddToObj("closed", Closed);
+    Result->AddToObj("label", Label);
     return Result;
 }
 

--- a/src/glib/mine/signalproc.cpp
+++ b/src/glib/mine/signalproc.cpp
@@ -907,14 +907,21 @@ TAggrResampler::TAggrResampler(const PJsonVal& ParamVal) {
     }
     // XXX decide if we should use NaN for default (max,min,avg are not defined for empty buffers)?
     DefaultVal = ParamVal->GetObjNum("defaultValue", 0);
+    Closed = ParamVal->GetObjStr("closed", "left");
+    EAssertR(Closed == "left" || Closed == "right", "TAggrResampler: closed should be 'left' or 'right'");
+    Label = ParamVal->GetObjStr("label", "left");
+    EAssertR(Closed == "left" || Closed == "right", "TAggrResampler: label should be 'left' or 'right'");
 }
 
 TAggrResampler::TAggrResampler(const uint64& Interval, const TStr& AggType,
-    const double& DefaultValue, const TStr& RoundStart, const TTm& Start)
+    const double& DefaultValue, const TStr& RoundStart, const TTm& Start,
+    const TStr& Closed, const TStr& Label)
     : IntervalMSecs(Interval), Type(GetType(AggType)), DefaultVal(DefaultValue) {
 
     EAssertR(RoundStart == "" || RoundStart == "h" || RoundStart == "m" ||
         RoundStart == "s", "TAggrResampler: roundStart should be 'h', 'm' or 's'");
+    EAssertR(Closed == "left" || Closed == "right", "TAggrResampler: closed should be 'left' or 'right'");
+    EAssertR(Label == "left" || Label == "right", "TAggrResampler: label should be 'left' or 'right'");
 
     if (Start.IsDef()) {
         uint64 StartTm = TTm::GetMSecsFromTm(Start);
@@ -1007,7 +1014,8 @@ bool TAggrResampler::TryResampleOnce(double& Val, uint64& Tm, bool& FoundEmptyP)
         // interval [LastResampPointMSecs + IntervalMSecs , LastResampPointMSecs + 2 * IntervalMSecs)
         // assert that we have not found a point older than the current window
         uint64 Start = LastResampPointMSecs + IntervalMSecs;
-        uint64 End = LastResampPointMSecs + 2 * IntervalMSecs - 1;
+        uint64 End = LastResampPointMSecs + 2 * IntervalMSecs;
+        int Edge = (Closed == "right") ? 0 : 1;
         while (!Buff.Empty()) {
             const TUInt64FltPr& Point = Buff.Top();
             if (Point.Val1 < Start) {
@@ -1016,7 +1024,7 @@ bool TAggrResampler::TryResampleOnce(double& Val, uint64& Tm, bool& FoundEmptyP)
                 Buff.Pop();
                 continue;
             }
-            if (Point.Val1 > End) { break; }
+            if (Point.Val1 > End - Edge) { break; }
             if (Type == TAggrResamplerType::artMax) {
                 Val = MAX(Val, Point.Val2.Val);
             } else if (Type == TAggrResamplerType::artMin) {
@@ -1037,11 +1045,11 @@ bool TAggrResampler::TryResampleOnce(double& Val, uint64& Tm, bool& FoundEmptyP)
             Val = DefaultVal;
             // printf("TAggrResampler:Nan generated while resampling and using average aggrgator (no data in the interval)\n");
         }
-        // new left point of the last successfully aggregated interval
-        Tm = LastResampPointMSecs + IntervalMSecs;
+        // new point of the last successfully aggregated interval
+        Tm = (Label == "right") ? End : Start;
         // save state
         LastResampPointVal = Val;
-        LastResampPointMSecs = Tm;
+        LastResampPointMSecs = Start;
     }
     return ResampleP;
 }

--- a/src/glib/mine/signalproc.h
+++ b/src/glib/mine/signalproc.h
@@ -773,6 +773,10 @@ private:
     TStr RoundStart;
     /// Default value when the buffer is empty
     TFlt DefaultVal;
+    /// Which side of bin interval is closed. The default is ‘left’.
+    TStr Closed;
+    /// Which bin edge label to label bucket with. The default is ‘left’.
+    TStr Label;
 
     // STATE
     /// Timestamp of the current time
@@ -791,7 +795,8 @@ public:
     TAggrResampler(const PJsonVal& ParamVal);
     /// Json constructor (sets interval, type and start time)
     TAggrResampler(const uint64& Interval, const TStr& AggType, const double& DefaultValue = 0,
-        const TStr& RoundStart = "", const TTm& Start = TTm());
+        const TStr& RoundStart = "", const TTm& Start = TTm(), const TStr& Closed = "left",
+        const TStr& Label = "left");
     /// Returns the parameters
     PJsonVal GetParams() const;
     /// Resets the state
@@ -1144,7 +1149,7 @@ public:
     /// Add a value to the t-digest.
     /// Argument *v* is the value to add.
     /// Argument *count* is the integer number of occurrences to add.
-    /// If not provided, *count* defaults to 1.    
+    /// If not provided, *count* defaults to 1.
     void Update(const double& V, const double& Count = 1);
     /// Is the model initialized?
     bool IsInit() const { return Updates >= MinPointsInit; }

--- a/src/glib/mine/signalproc.h
+++ b/src/glib/mine/signalproc.h
@@ -795,8 +795,8 @@ public:
     TAggrResampler(const PJsonVal& ParamVal);
     /// Json constructor (sets interval, type and start time)
     TAggrResampler(const uint64& Interval, const TStr& AggType, const double& DefaultValue = 0,
-        const TStr& RoundStart = "", const TTm& Start = TTm(), const TStr& Closed = "left",
-        const TStr& Label = "left");
+        const TStr& RoundStart = "", const TStr& Closed = "left", const TStr& Label = "left",
+        const TTm& Start = TTm());
     /// Returns the parameters
     PJsonVal GetParams() const;
     /// Resets the state

--- a/src/glib/mine/signalproc.h
+++ b/src/glib/mine/signalproc.h
@@ -758,7 +758,10 @@ typedef enum { artSum, artAvg, artMin, artMax } TAggrResamplerType;
 ///        - init (true if at least one resampling happened)
 /// Parameters: - interval size
 ///             - type of aggregation (sum or avg)
+///             - default value (by default it is 0)
 ///             - RoundStart ('h', 'm', 's') - strips away (m,s,msec) if set to h, strips (s,msec) if set to m, ...
+///             - Closed - 'left' or 'right' closed interval. The default is 'left'
+///             - Label - resampled time points timestamps correspond to 'left' or 'right' edge (default is 'left')
 /// Main logic: TryResampleOnce
 ///               Resampling is possible if there exists an interval (of predefined width)
 ///               that ends before current time and starts at last resample time point.
@@ -773,9 +776,11 @@ private:
     TStr RoundStart;
     /// Default value when the buffer is empty
     TFlt DefaultVal;
-    /// Which side of bin interval is closed. The default is ‘left’.
+    /// Interval are half closed. This parameter defines which side is closed.
+    /// Either 'left' or 'right'. The default is ‘left’.
     TStr Closed;
-    /// Which bin edge label to label bucket with. The default is ‘left’.
+    /// Either 'left' or 'right'. Resampled time-series time points can correspond to
+    /// bucket start points (left) or bucket end points (right). The default is ‘left’.
     TStr Label;
 
     // STATE


### PR DESCRIPTION
- `Closed`: Which side of bin interval is closed. The default is ‘left’.
- `Label`: Which bin edge label to label bucket with. The default is ‘left’.

Ref: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.resample.html#pandas.DataFrame.resample